### PR TITLE
Add ServeFiles method to allow serving files from disk

### DIFF
--- a/cobalt.go
+++ b/cobalt.go
@@ -143,6 +143,13 @@ func (c *Cobalt) Head(route string, h Handler, m ...MiddleWare) {
 	c.route("HEAD", route, h, m)
 }
 
+// ServeFiles serves files from the given file system root.
+// The path must end with "/*filepath", files are then served from the local
+// path /defined/root/dir/*filepath.
+func (c *Cobalt) ServeFiles(path string, root http.FileSystem) {
+	c.router.ServeFiles(path, root)
+}
+
 // ServeHTTP implements the HandlerFunc that process the http request.
 func (c *Cobalt) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	c.router.ServeHTTP(w, req)


### PR DESCRIPTION
While developing a single page app I would like to serve up the html,
css, and js alongside my API. I added a ServeFiles method to Cobalt to
provide access to httprouter's method of the same name.
